### PR TITLE
Improvements (see changelog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Atun - AWS Tagged Tunnel
-[![E2E Tests](https://github.com/automationd/atun/actions/workflows/pr.yml/badge.svg)](https://github.com/AutomationD/atun/actions/workflows/pr.yml)
+[![E2E Tests](https://github.com/automationd/atun/actions/workflows/tests.yml/badge.svg)](https://github.com/AutomationD/atun/actions/workflows/tests.yml)
 
 SSH tunnel cli tool that works without local configuration. It uses EC2 tags to define hosts and ports forwarding
 configuration.

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -98,7 +98,7 @@ var createCmd = &cobra.Command{
 
 				// Ask user to pick a subnet
 				err = survey.AskOne(&survey.Select{
-					Message: "Select Subnet ID:",
+					Message: "Bastion Instance will be deployed.\nSelect Subnet ID:",
 					Options: func() []string {
 						var options []string
 						for _, subnet := range subnets {
@@ -133,7 +133,7 @@ var createCmd = &cobra.Command{
 		showSpinner := config.App.Config.LogLevel != "debug" && config.App.Config.LogLevel != "info"
 
 		if showSpinner {
-			createBastionInstanceSpinner, _ = pterm.DefaultSpinner.Start("Creating Ad-Hoc EC2 Bastion Instance...")
+			createBastionInstanceSpinner = logger.StartCustomSpinner("Creating Ad-Hoc EC2 Bastion Instance...")
 		} else {
 			logger.Debug("Not showing spinner", "logLevel", config.App.Config.LogLevel)
 			logger.Info("Creating Ad-Hoc EC2 Bastion Instance...")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -90,10 +90,10 @@ var createCmd = &cobra.Command{
 		if config.App.Config.BastionVPCID == "" {
 			if config.App.Config.BastionSubnetID == "" {
 				logger.Info("No Subnet ID provided. Asking for it.")
-				// Get list of subnets in the account (via GetAvailableSubnets) and ask the user to pick one with survey
-				subnets, err := aws.GetAvailableSubnets()
+				// Get list of subnets in the account (via GetSubnetsWithSSM) and ask the user to pick one with survey
+				subnets, err := aws.GetSubnetsWithSSM()
 				if err != nil {
-					logger.Fatal("Error getting available subnets", "err", err)
+					logger.Fatal("Error getting subnets with SSM", "err", err)
 				}
 
 				// Ask user to pick a subnet
@@ -106,6 +106,7 @@ var createCmd = &cobra.Command{
 						}
 						return options
 					}(),
+					Help: "If you don't see your subnets it means there is no SSM connectivity there",
 					Description: func(value string, index int) string {
 						var name string
 						for _, tag := range subnets[index].Tags {
@@ -114,7 +115,7 @@ var createCmd = &cobra.Command{
 							}
 
 						}
-						return fmt.Sprintf("CIDR: %s, Name: %s, VPC ID: %s", *subnets[index].CidrBlock, name, *subnets[index].VpcId)
+						return fmt.Sprintf("SSM: OK, CIDR: %s, Name: %s, VPC ID: %s", *subnets[index].CidrBlock, name, *subnets[index].VpcId)
 					},
 				}, &config.App.Config.BastionSubnetID, survey.WithValidator(survey.Required))
 			}
@@ -198,8 +199,8 @@ func buildHostConfig(app *config.Atun) error {
 
 	aws.InitAWSClients(config.App)
 
-	// Get list of subnets in the account (via GetAvailableSubnets) to use as default values
-	subnets, err := aws.GetAvailableSubnets()
+	// Get list of subnets in the account (via GetSubnetsWithSSM) to use as default values
+	subnets, err := aws.GetSubnetsWithSSM()
 	if err != nil {
 		log.Fatalf("Error getting available subnets: %v", err)
 		return err

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,7 +27,7 @@ var deleteCmd = &cobra.Command{
 		showSpinner := config.App.Config.LogLevel != "debug" && config.App.Config.LogLevel != "info"
 
 		if showSpinner {
-			deleteBastionInstanceSpinner, _ = pterm.DefaultSpinner.Start("Deleting Ad-Hoc EC2 Bastion Instance...")
+			deleteBastionInstanceSpinner = logger.StartCustomSpinner("Deleting Ad-Hoc EC2 Bastion Instance...")
 		} else {
 			logger.Debug("Not showing spinner", "logLevel", config.App.Config.LogLevel)
 			logger.Info("Deleting Ad-Hoc EC2 Bastion Instance...")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,7 +18,7 @@ var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Deletes an ad-hoc bastion host",
 	Long:  `Deletes an ad-hoc bastion host created by atun. Performed via CDKTF/Terraform: doesn't affect other resources`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// TODO: Add check for --force flag
 
 		// TODO: Add survey to check if the user is sure to destroy the stack
@@ -43,7 +43,7 @@ var deleteCmd = &cobra.Command{
 				logger.Error("Failed to delete Bastion Ad-Hoc Instance")
 			}
 			logger.Error("Error running CDKTF", "error", err)
-			return
+			return err
 		}
 
 		if showSpinner {
@@ -52,6 +52,7 @@ var deleteCmd = &cobra.Command{
 			logger.Info("Bastion Ad-Hoc Instance deleted successfully")
 		}
 		logger.Info("CDKTF stack destroyed successfully")
+		return nil
 	},
 }
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -44,7 +44,7 @@ var downCmd = &cobra.Command{
 		}
 
 		if showSpinner {
-			downTunnelSpinner, _ = pterm.DefaultSpinner.Start("Stopping tunnel...")
+			downTunnelSpinner = logger.StartCustomSpinner("Stopping tunnel...")
 		} else {
 			logger.Debug("Not showing spinner", "logLevel", config.App.Config.LogLevel)
 			logger.Info("Stopping tunnel...")
@@ -55,7 +55,7 @@ var downCmd = &cobra.Command{
 			bastionHost = cmd.Flag("bastion").Value.String()
 
 			if showSpinner {
-				downTunnelSpinner, _ = pterm.DefaultSpinner.Start(fmt.Sprintf("Stopping tunnel via bastion host %s...", config.App.Config.BastionHostID))
+				downTunnelSpinner = logger.StartCustomSpinner(fmt.Sprintf("Stopping tunnel via bastion host %s...", config.App.Config.BastionHostID))
 			} else {
 				logger.Debug("Not showing spinner", "logLevel", config.App.Config.LogLevel)
 				logger.Info("Stopping tunnel via EC2 Bastion Instance...")
@@ -83,7 +83,7 @@ var downCmd = &cobra.Command{
 			}
 		}
 		if showSpinner {
-			downTunnelSpinner.Success("Tunnel stopped")
+			downTunnelSpinner.Success("Tunnel is stopped")
 		} else {
 			logger.Debug("Tunnel status", "status", tunnelStarted)
 		}
@@ -93,7 +93,7 @@ var downCmd = &cobra.Command{
 		deleteBastion, _ := cmd.Flags().GetBool("delete")
 
 		if deleteBastion {
-			logger.Info("Delete flag is set. Deleting bastсion host", "bastion", config.App.Config.BastionHostID)
+			logger.Info("Delete flag is set. Deleting bastion host", "bastion", config.App.Config.BastionHostID)
 
 			// Run create command from here
 			err := deleteCmd.RunE(deleteCmd, args)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,10 +68,10 @@ func init() {
 
 	// TODO: Use Method Receiver (pass atun all the way to the command)
 	rootCmd.AddCommand(
+		deleteCmd,
+		createCmd,
 		upCmd,
 		downCmd,
-		createCmd,
-		deleteCmd,
 		statusCmd,
 		versionCmd,
 	)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"github.com/automationd/atun/internal/aws"
 	"github.com/automationd/atun/internal/config"
+	"github.com/automationd/atun/internal/logger"
+	"github.com/automationd/atun/internal/tunnel"
 
 	"github.com/pterm/pterm"
 	"os"
@@ -25,6 +27,7 @@ var statusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// TODO: Implement Tunnel Status
 
+		logger.Debug("Status command called")
 		cwd, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("can't load options for a command: %w", err)
@@ -33,6 +36,11 @@ var statusCmd = &cobra.Command{
 		dt := pterm.DefaultTable
 
 		aws.InitAWSClients(config.App)
+
+		config.App.Config.BastionHostID, err = tunnel.GetBastionHostID()
+		if err != nil {
+			logger.Error("Bastion host not found. You might want to create it.", "error", err)
+		}
 
 		// TODO: Hide this info behind --debug flag or move to a `debug` command
 		pterm.DefaultSection.Println("Status")
@@ -44,11 +52,12 @@ var statusCmd = &cobra.Command{
 			{"SSH_KEY_PATH", config.App.Config.SSHKeyPath},
 			{"Config File", config.App.Config.ConfigFile},
 			{"Bastion Host", config.App.Config.BastionHostID},
+			{"Log Level", config.App.Config.LogLevel},
 
 			//{"Toggle", toggleValue},
 		}).WithLeftAlignment().Render()
-
-		return err
+		logger.Debug("Status command finished")
+		return nil
 	},
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -139,7 +139,7 @@ var upCmd = &cobra.Command{
 		logger.Debug("Public key", "key", publicKey)
 
 		// Send the public key to the bastion instance
-		err = aws.SendSSHPublicKey(config.App.Config.BastionHostID, publicKey)
+		err = aws.SendSSHPublicKey(config.App.Config.BastionHostID, publicKey, config.App.Config.BastionHostUser)
 		if err != nil {
 			logger.Fatal("Error adding local SSH Public key to the instance", "SSHPublicKey", publicKey, "BastionHostID", config.App.Config.BastionHostID, "error", err)
 			os.Exit(1)

--- a/examples/simple/atun.example.toml
+++ b/examples/simple/atun.example.toml
@@ -1,9 +1,10 @@
 # This is a sample config file that is used when atun cli is ued to deploy a Bastion Host.
 # It's not required when connecting to an existing Bastion Host that is tagged with atun-compatible tags.
 
-aws_profile="localstack"
+#aws_profile="localstack"
 aws_region="us-east-1"
-bastion_subne_id="subnet-xxxxxxxxxxxxxxxx"
+#bastion_subnet_id="subnet-xxxxxxxxxxxxxxxx"
+#bastion_subnet_id="subnet-77c1c72b"
 
 [[hosts]]
 name = "ipconfig.io"

--- a/internal/aws/auth.go
+++ b/internal/aws/auth.go
@@ -58,6 +58,7 @@ func GetSession(c *SessionConfig) (*session.Session, error) {
 	}
 
 	if c.Region == "" {
+		logger.Debug("Region is not set, trying to get it from the credentials file", "profile", c.Profile)
 		c.Region = profile.Key("region").String()
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,9 +39,11 @@ type Config struct {
 	BastionHostID            string
 	BastionInstanceName      string
 	BastionHostAMI           string
+	BastionHostUser          string
 	AppDir                   string
 	TunnelDir                string
 	LogLevel                 string
+	LogPlainText             bool
 	Env                      string
 	AutoAllocatePort         bool
 }
@@ -74,8 +76,8 @@ func LoadConfig() error {
 	// Set default log level early
 	viper.SetDefault("LOG_LEVEL", "info")
 
-	// Initialize the logger for a bit to provide early logging
-	logger.Initialize(viper.GetString("LOG_LEVEL"))
+	// Initialize the logger for a bit to provide early logging (using viper defaults)
+	logger.Initialize(viper.GetString("LOG_LEVEL"), viper.GetBool("LOG_PLAIN_TEXT"))
 
 	currentDir, err := os.Getwd()
 	if err != nil {
@@ -105,8 +107,8 @@ func LoadConfig() error {
 		logger.Debug("Using config file:", "configFile", viper.ConfigFileUsed())
 	}
 
-	// Initialize the logger after config is read (second time)
-	logger.Initialize(viper.GetString("LOG_LEVEL"))
+	// Initialize the logger after config is read (second time, getting log level and plain text setting from config)
+	logger.Initialize(viper.GetString("LOG_LEVEL"), viper.GetBool("LOG_PLAIN_TEXT"))
 
 	// Use AWS_PROFILE env var as a default for viper AWS_PROFILE
 	if viper.GetString("ENV") == "" {
@@ -146,8 +148,10 @@ func LoadConfig() error {
 	viper.SetDefault("SSH_STRICT_HOST_KEY_CHECKING", true)
 	viper.SetDefault("AWS_INSTANCE_TYPE", "t3.nano")
 	viper.SetDefault("BASTION_INSTANCE_NAME", "atun-bastion")
+	viper.SetDefault("BASTION_HOST_USER", "ec2-user")
 	viper.SetDefault("SSH_STRICT_HOST_KEY_CHECKING", false) // Strict host key checking is disabled by default for better user experience. Debatable
 	viper.SetDefault("AUTO_ALLOCATE_PORT", false)           // Port auto-allocation is disabled by default
+	viper.SetDefault("LOG_PLAIN_TEXT", false)
 
 	// TODO?: Move init a separate file with correct imports of config
 	App = &Atun{
@@ -167,9 +171,11 @@ func LoadConfig() error {
 			BastionHostID:            viper.GetString("BASTION_HOST_ID"),
 			BastionInstanceName:      viper.GetString("BASTION_INSTANCE_NAME"),
 			BastionHostAMI:           viper.GetString("BASTION_HOST_AMI"),
+			BastionHostUser:          viper.GetString("BASTION_HOST_USER"),
 			ConfigFile:               viper.ConfigFileUsed(),
 			AppDir:                   appDir,
 			LogLevel:                 viper.GetString("LOG_LEVEL"),
+			LogPlainText:             viper.GetBool("LOG_PLAIN_TEXT"),
 			AutoAllocatePort:         viper.GetBool("AUTO_ALLOCATE_PORT"),
 		},
 		Session: nil,

--- a/internal/infra/cdktf.go
+++ b/internal/infra/cdktf.go
@@ -165,30 +165,35 @@ func ApplyCDKTF(c *config.Config) error {
 	synthDir := filepath.Join(c.TunnelDir, "stacks", fmt.Sprintf("%s-%s", c.AWSProfile, c.Env))
 	cmd := exec.Command("terraform", "init")
 	cmd.Dir = synthDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if c.LogLevel == "info" || c.LogLevel == "debug" {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	if err := cmd.Run(); err != nil {
 		return err
 	}
 
 	// TODO: Manage Terraform / OpenTofu Install
-
 	cmd = exec.Command("terraform", "apply", "-auto-approve")
 	cmd.Dir = synthDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if c.LogLevel == "info" || c.LogLevel == "debug" {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
 	return cmd.Run()
 }
 
-// DestroyCDKTF performs the 'destroy' of the CDKTF stack
 func DestroyCDKTF(c *config.Config) error {
 	createStack(c)
 	// Change to the synthesized directory
 	synthDir := filepath.Join(c.TunnelDir, "stacks", fmt.Sprintf("%s-%s", c.AWSProfile, c.Env))
 	cmd := exec.Command("terraform", "init")
 	cmd.Dir = synthDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if c.LogLevel == "info" || c.LogLevel == "debug" {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	if err := cmd.Run(); err != nil {
 		return err
 	}
@@ -196,7 +201,9 @@ func DestroyCDKTF(c *config.Config) error {
 	// TODO: Manage Install Terraform
 	cmd = exec.Command("terraform", "destroy", "-auto-approve")
 	cmd.Dir = synthDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if c.LogLevel == "info" || c.LogLevel == "debug" {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	return cmd.Run()
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -6,6 +6,7 @@
 package logger
 
 import (
+	"github.com/pterm/pterm"
 	"github.com/spf13/viper"
 	"log/slog"
 	"os"
@@ -15,7 +16,8 @@ import (
 var defaultLogger *slog.Logger
 
 // Initialize sets up the logger with a specified log level
-func Initialize(logLevel string) {
+func Initialize(logLevel string, logPlainText bool) {
+
 	// Map log levels from configuration to slog
 	var slogLevel slog.Level
 	switch strings.ToLower(logLevel) {
@@ -36,11 +38,13 @@ func Initialize(logLevel string) {
 	}
 
 	// Configure slog with a text handler
-	opts := slog.HandlerOptions{Level: slogLevel}
-	handler := slog.NewTextHandler(os.Stdout, &opts)
-	defaultLogger = slog.New(handler)
+	handler := pterm.NewSlogHandler(&pterm.DefaultLogger)
 
-	// Log initialization message
+	// Change the log level to debug to enable debug messages
+	pterm.DefaultLogger.Level = pterm.LogLevelDebug
+
+	// Create a new slog logger with the handler
+	defaultLogger = slog.New(handler)
 	defaultLogger.Debug("Logger initialized", "level", slogLevel.String())
 }
 
@@ -51,26 +55,31 @@ func Info(msg string, keysAndValues ...interface{}) {
 
 // Debug logs a debug message
 func Debug(msg string, keysAndValues ...interface{}) {
+
 	defaultLogger.Debug(msg, keysAndValues...)
+
 }
 
 // Warn logs a warning message
 func Warn(msg string, keysAndValues ...interface{}) {
 	defaultLogger.Warn(msg, keysAndValues...)
+
 }
 
 // Error logs an error message
 func Error(msg string, keysAndValues ...interface{}) {
 	defaultLogger.Error(msg, keysAndValues...)
+
 }
 
 // Fatal logs a fatal error message and exits the application
 func Fatal(msg string, keysAndValues ...interface{}) {
 	defaultLogger.Error(msg, keysAndValues...)
 	os.Exit(1)
+
 }
 
 func init() {
 	// Initialize the logger with the default log level
-	Initialize(viper.GetString("LOG_LEVEL"))
+	Initialize(viper.GetString("LOG_LEVEL"), false)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 )
 
 var defaultLogger *slog.Logger
@@ -115,6 +116,32 @@ func Success(msg string) {
 	}
 
 	pterm.Success.Println(msg)
+}
+
+// StartCustomSpinner creates and starts a fresh custom spinner
+func StartCustomSpinner(message string) *pterm.SpinnerPrinter {
+	// Clone DefaultSpinner as a new variable
+	spinner := pterm.DefaultSpinner // Direct assignment to create a new copy
+
+	// Customize the spinner
+	spinner.Sequence = []string{
+		"    🐟",
+		"   🐟 ",
+		"  🐟  ",
+		" 🐟   ",
+		"🐟    ",
+		//"🫧   ",
+		//" 🫧  ",
+		//"  🫧 ",
+		//"   🫧",
+	}
+
+	spinner.Style = pterm.NewStyle(pterm.FgCyan) // Custom color
+	spinner.Delay = 150 * time.Millisecond       // Frame delay
+
+	// Start the spinner
+	s, _ := spinner.Start(message)
+	return s
 }
 
 func init() {

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -108,8 +108,8 @@ func GetSSHCommandArgs(app *config.Atun) []string {
 			args = append(args, "-o", "StrictHostKeyChecking=no")
 		}
 
-		// TODO: Add ability to support other instance types, not just ubuntu
-		args = append(args, fmt.Sprintf("ec2-user@%s", app.Config.BastionHostID))
+		// TODO: Add ability to support other instance types, not just AWS Linux
+		args = append(args, fmt.Sprintf("%s@%s", app.Config.BastionHostUser, app.Config.BastionHostID))
 		args = append(args, "-F", app.Config.SSHConfigFile)
 
 		if _, err := os.Stat(app.Config.SSHKeyPath); !os.IsNotExist(err) {

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -69,7 +69,7 @@ func RunSSH(app *config.Atun, args []string) error {
 	//}
 	// Run the command
 	if err := c.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "SSH command error: %v\n", err)
+		logger.Debug("SSH command error", "error", err)
 		return fmt.Errorf("failed to run SSH process: %w", err)
 
 		// Print stdot and stderr from the command


### PR DESCRIPTION
# What's in the PR
- Assume region from shared creds file
- Language updates
- Improve sendSSHKey function
- Add ability to override EC2 instance SSH user
- Use pterm slog
- Add spinner to create instance (WIP)
- Fix stopping tunnel when it's down
- Add ability to check subnet access (via gateways routes)
- If subnet is public use public_subnets in the Terraform module
- Improve UX on create
- Switch delete command to RunE
- Add spinner to down command
- Reorder commands in root (not sure if needed?)
- Use logger debug to show ssh output issue (not fmt to stdout)
- Add ability to auto-create adhoc bastion instance
- Improve spinner for all commands
- Disable spinner in debug and info
- Infer port based on the host (via AWS SDK)
- Default logging set to warning
- Add more logging
- Add ability to save config after initial run
- Add ability to pick subnet, and ssh key
- Add custom logging prefixes and style
- Cleanup log levels
- Improve clean `up` workflow (to run another create if needed and such)
- Calculate local port based on the remote port (just a suggestion during initial wizard)
- Infer AWS region based on session (don't require it as a constraint)
- Wait until the instance becomes ready for ssm after creation
- Assume region from shared creds file
- Language updates
- Improve sendSSHKey function
- Add ability to overide EC2 instance SSH user
- Use pterm slog
- Add spinner to create instance (WIP)
- Custom Pterm style