### PR TITLE
Fix Homebrew conflict config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,7 +52,6 @@ brews:
     license: "Apache 2.0"
     conflicts:
       - atun-dev
-      - atun-dev@{{ .Version }}
 
     test: |
       system "#{bin}/atun --version"


### PR DESCRIPTION
# Contents
Fix Homebrew conflict config so homebrew doesn't show a warning (we don't do dev versions any more, and there is only one 0.0.0.