### PR TITLE
Rename Bastion to Router and add router management commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ demo/
 cdktf.out/
 dist/
 coverage.out
+atun.toml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _(This is a MOCK Demo. Will update it soon)_
 
 ## Features
 
-This tool allows to connect to private resources (RDS, Redis, etc) via EC2 bastion hosts without public IP (via SSM).
+This tool allows to connect to private resources (RDS, Redis, etc) via EC2 router hosts without public IP (via SSM).
 At the moment there are only three commands available: `up`, `down`, and `status`.
 
 ## Tag Metadata Schema
@@ -44,29 +44,47 @@ At the moment it has two types of tags: Atun Version and Atun Host.
 
 - local: port that would be bound on a local machine (your computer)
 - proto: protocol of forwarding (only `ssm` for now, but might be `k8s` or `cloudflare`)
-- remote: port that is available on the internal network to the bastion host.
+- remote: port that is available on the internal network to the router host.
 
 ### Example
 
 | AWS Tag                                                                        | Value                                           | Description                                                               |
 |--------------------------------------------------------------------------------|-------------------------------------------------|---------------------------------------------------------------------------|
 | `atun.io/version`                                                              | `1`                                             | Schema Version. It might change if significant changes would be intoduced |
-| `atun.io/env`                                                                  | `dev`                                           | Specified environment of the bastion host                                 |
+| `atun.io/env`                                                                  | `dev`                                           | Specified environment of the router host                                 |
 | `atun.io/host/nutcorp-api.cluster-xxxxxxxxxxxxxxx.us-east-1.rds.amazonaws.com` | `{"local":"23306","proto":"ssm","remote":3306}` | Describes host config and how to forward ports for a MySQL RDS            |
 | `atun.io/host/nutcorp.xxxxxx.0001.use0.cache.amazonaws.com`                    | `{"local":"26379","proto":"ssm","remote":6379}` | Describes host config and how to forward ports for ElastiCache Redis      |
 
 ## Usage
-There are two ways to use this tool: when an infra has a bastion with `atun.io` schema tags and when it doesn't have it yet.
+There are two ways to use this tool: when an infra has a router with `atun.io` schema tags and when it doesn't have it yet.
 
-### Create a Bastion Host
-When an infra doesn't have a bastion host yet (let's say this is an adhoc connection), it's possible to create a bastion host with this tool.
+### Manage Router Endpoints
+Atun uses "routers" (such as EC2 routers) to establish secure connections to your infrastructure.
 
+#### Create a Router
 ```shell
-atun create
+atun router create
+```
+
+#### List Available Routers
+```shell
+atun router ls
+```
+
+#### Connect to a Router
+For troubleshooting or direct access:
+```shell
+atun router shell
+```
+A relevant protocol will be used, such as SSM.
+
+#### Delete a Router
+```shell
+atun router delete
 ```
 
 ### Bring up a tunnel
-This will bring an tunnel via existing atun.io bastion
+This will bring up a tunnel via existing atun.io router
 ```shell
 atun up
 ```
@@ -81,12 +99,12 @@ atun down
 atun status
 ```
 
-### Create a bastion host and connect in one go
+### Create a router and connect in one go
 ```shell
 atun up --create
 ```
 
-### Bring down a tunnel and delete ad-hoc bastion host
+### Bring down a tunnel and delete ad-hoc router
 ```shell
 atun down --delete
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,12 +7,13 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/automationd/atun/internal/config"
 	"github.com/automationd/atun/internal/constraints"
 	"github.com/automationd/atun/internal/logger"
 	"github.com/pterm/pterm"
 	"github.com/spf13/viper"
-	"path/filepath"
 
 	//"github.com/automationd/atun/internal/config"
 	"os"
@@ -69,12 +70,11 @@ func init() {
 
 	// TODO: Use Method Receiver (pass atun all the way to the command)
 	rootCmd.AddCommand(
-		deleteCmd,
-		createCmd,
 		upCmd,
 		downCmd,
 		statusCmd,
 		versionCmd,
+		routerCmd,
 	)
 
 	//cobra.OnInitialize(config.LoadConfig)

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// RouterInfo represents the information about a router
+type RouterInfo struct {
+	ID        string
+	Type      string
+	State     string
+	CreatedAt time.Time
+}
+
+// routerCmd represents the router command
+var routerCmd = &cobra.Command{
+	Use:   "router",
+	Short: "Manage connection routers",
+	Long: `Commands for creating, connecting to, and managing router endpoints 
+that facilitate secure connections to your infrastructure.
+	
+Available router types:
+- EC2: Amazon EC2 router hosts
+- Kubernetes (planned): Kubernetes pods acting as jump hosts
+- ECS (planned): Amazon ECS containers for connecting to services`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// By default, don't do anything
+		return nil
+	},
+}
+
+func init() {
+	routerCmd.AddCommand(routerShellCmd)
+	routerCmd.AddCommand(routerListCmd)
+	routerCmd.AddCommand(routerCreateCmd)
+	routerCmd.AddCommand(routerDeleteCmd)
+	routerCmd.AddCommand(routerInstallCmd)
+	routerCmd.AddCommand(routerUninstallCmd)
+
+}

--- a/cmd/router_delete.go
+++ b/cmd/router_delete.go
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * SPDX-FileCopyrightText: © 2024 Dmitry Kireev
  */
+
 package cmd
 
 import (
@@ -15,8 +16,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deleteCmd represents the del command
-var deleteCmd = &cobra.Command{
+// routerDeleteCmd represents the del command
+var routerDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Deletes an ad-hoc router host",
 	Long:  `Deletes an ad-hoc router host created by atun. Performed via CDKTF/Terraform: doesn't affect other resources`,
@@ -59,5 +60,4 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	logger.Debug("Init delete command")
 }

--- a/cmd/router_install.go
+++ b/cmd/router_install.go
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: © 2024 Dmitry Kireev
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/spf13/cobra"
+
+	awsLib "github.com/automationd/atun/internal/aws"
+	"github.com/automationd/atun/internal/config"
+	"github.com/automationd/atun/internal/constraints"
+	"github.com/automationd/atun/internal/logger"
+	"github.com/automationd/atun/internal/ux"
+)
+
+// routerInstallCmd represents the router install command
+var routerInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install Atun tags on an existing EC2 instance",
+	Long: `Install Atun tags on an existing EC2 instance to use it as a router.
+This allows you to use an existing instance as an Atun router without creating a new one.
+
+Example:
+  atun router install --router i-1234abcd  # Install Atun tags on instance i-1234abcd`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		var routerHost string
+
+		// Get the router host ID from the command line
+		routerHost = cmd.Flag("router").Value.String()
+		if routerHost == "" {
+			return fmt.Errorf("router instance ID is required. Use --router flag to specify")
+		}
+
+		config.App.Config.RouterHostID = routerHost
+
+		// Check if the configuration is loaded
+		if config.App.Config != nil {
+			logger.Debug("App config exists (via file, env vars or else). Checking Hosts Config")
+
+			// If config is not loaded, offer to create a new configuration using survey package
+			if len(config.App.Config.Hosts) == 0 {
+				// TODO Add build config
+				logger.Fatal("No hosts found in the configuration. Please create atun.toml")
+
+			}
+			// TODO: Check for Subnet ID and if not ask for them
+			logger.Debug("Hosts Config exists.", "hosts", config.App.Config.Hosts)
+		} else {
+			logger.Warn("No configuration file found.")
+		}
+
+		// Create a spinner
+		installSpinner := ux.NewProgressSpinner("Installing Atun on existing instance")
+
+		// Check constraints
+		if err := constraints.CheckConstraints(
+			constraints.WithAWSProfile(),
+			constraints.WithENV(),
+		); err != nil {
+			installSpinner.Fail("Constraint check failed")
+			return err
+		}
+
+		// Initialize AWS clients
+		installSpinner.UpdateText("Authenticating with AWS...")
+		awsLib.InitAWSClients(config.App)
+
+		// Get router instance ID from flag
+		routerID, _ := cmd.Flags().GetString("router")
+		if routerID == "" {
+			installSpinner.Fail("No router instance ID provided")
+			return fmt.Errorf("router instance ID is required. Use --router flag to specify")
+		}
+
+		// TODO: abstract EC2 stuff into aws package
+		// Verify instance exists
+		installSpinner.UpdateText(fmt.Sprintf("Verifying instance %s exists...", routerID))
+		ec2Client, err := awsLib.NewEC2Client(*config.App.Session.Config)
+		if err != nil {
+			installSpinner.Fail(fmt.Sprintf("Failed to create EC2 client: %v", err))
+			return err
+		}
+
+		_, err = ec2Client.DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(routerID)},
+		})
+		if err != nil {
+			installSpinner.Fail(fmt.Sprintf("Instance %s not found: %v", routerID, err))
+			return fmt.Errorf("instance %s not found: %w", routerID, err)
+		}
+
+		// Create tags for the instance
+		installSpinner.UpdateText("Creating Atun tags...")
+
+		// Create EC2 tags array
+		var tags []*ec2.Tag
+
+		// Add version and environment tags
+		tags = append(tags, &ec2.Tag{
+			Key:   aws.String("atun.io/version"),
+			Value: aws.String(config.App.Version),
+		})
+
+		tags = append(tags, &ec2.Tag{
+			Key:   aws.String("atun.io/env"),
+			Value: aws.String(config.App.Config.Env),
+		})
+
+		// Process each host and add it to the tags
+		for _, host := range config.App.Config.Hosts {
+			key := fmt.Sprintf("atun.io/host/%s", host.Name)
+			hostConfig := map[string]interface{}{
+				"proto":  host.Proto,
+				"local":  host.Local,
+				"remote": host.Remote,
+			}
+
+			configJSON, err := json.Marshal(hostConfig)
+			if err != nil {
+				installSpinner.Fail(fmt.Sprintf("Failed to marshal host config: %v", err))
+				return fmt.Errorf("failed to marshal host config: %w", err)
+			}
+
+			tags = append(tags, &ec2.Tag{
+				Key:   aws.String(key),
+				Value: aws.String(string(configJSON)),
+			})
+		}
+
+		// Apply tags to the instance
+		_, err = ec2Client.CreateTags(&ec2.CreateTagsInput{
+			Resources: []*string{aws.String(routerID)},
+			Tags:      tags,
+		})
+		if err != nil {
+			installSpinner.Fail(fmt.Sprintf("Failed to apply tags: %v", err))
+			return fmt.Errorf("failed to apply tags: %w", err)
+		}
+
+		// Update the router host ID in config
+		config.App.Config.RouterHostID = routerID
+
+		installSpinner.Success(fmt.Sprintf("Successfully installed Atun on instance %s", routerID))
+		logger.Info(fmt.Sprintf("Router installed on instance ID: %s", routerID))
+		logger.Info("To connect to your infrastructure, run: atun up")
+
+		return nil
+	},
+}
+
+func init() {
+	routerInstallCmd.Flags().String("router", "", "ID of the existing EC2 instance to install Atun on (required)")
+	routerInstallCmd.MarkFlagRequired("router")
+}

--- a/cmd/router_list.go
+++ b/cmd/router_list.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/pterm/pterm"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/automationd/atun/internal/aws"
+	"github.com/automationd/atun/internal/config"
+	"github.com/automationd/atun/internal/logger"
+	"github.com/automationd/atun/internal/tunnel"
+	"github.com/automationd/atun/internal/ux"
+)
+
+// routerListCmd represents the router list command
+var routerListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List available routers",
+	Long: `List all available routers and their current status.
+
+Example:
+  atun router list      # List all available routers
+  atun router ls        # Same as above (shorter syntax)`,
+	RunE: listRouters,
+}
+
+// listRouters displays a list of available routers
+func listRouters(cmd *cobra.Command, args []string) error {
+	// Create progress spinner
+	spinner := ux.NewProgressSpinner("Discovering available routers")
+
+	// Initialize AWS clients
+	spinner.UpdateText("Authenticating with AWS...")
+	aws.InitAWSClients(config.App)
+
+	// Get routers (routers) with atun.io tags
+	spinner.UpdateText("Searching for routers...")
+	instanceIDs, err := tunnel.GetRouterHostIDFromTags()
+	if err != nil {
+		spinner.Fail("Failed to discover routers")
+		return fmt.Errorf("error listing routers: %w", err)
+	}
+
+	// Convert single ID to slice if needed
+	var routerIDs []string
+	if instanceIDs != "" {
+		routerIDs = []string{instanceIDs}
+	} else {
+		routerIDs = []string{}
+	}
+
+	if len(routerIDs) == 0 {
+		spinner.Success("Search completed")
+		logger.Info("No routers found. Create one with 'atun router create'")
+		return nil
+	}
+
+	// Fetch details for each router
+	spinner.UpdateText(fmt.Sprintf("Found %d router(s), fetching details...", len(routerIDs)))
+	routers := []RouterInfo{}
+
+	// Process each instance
+	for _, id := range routerIDs {
+		instance, err := getEC2InstanceDetails(id)
+		if err != nil {
+			logger.Warn(fmt.Sprintf("Could not get details for router %s", id), "error", err)
+			continue
+		}
+
+		routers = append(routers, instance)
+	}
+
+	// Display routers in a table
+	renderRouterTable(routers)
+
+	return nil
+}
+
+// getEC2InstanceDetails retrieves EC2 instance details
+// This is a helper function that uses available AWS functions in your codebase
+func getEC2InstanceDetails(instanceID string) (RouterInfo, error) {
+	// Use your existing AWS functions to get instance details
+	// This might be something like aws.DescribeInstance
+
+	// For now, create a placeholder instance with basic information
+	router := RouterInfo{
+		ID:        instanceID,
+		Type:      "ec2",
+		State:     "running",
+		CreatedAt: time.Now(),
+	}
+
+	return router, nil
+}
+
+// renderRouterTable displays a formatted table of routers
+func renderRouterTable(routers []RouterInfo) {
+	if len(routers) == 0 {
+		logger.Info("No routers found")
+		return
+	}
+
+	// Sort routers by creation time (newest first)
+	sort.Slice(routers, func(i, j int) bool {
+		return routers[i].CreatedAt.After(routers[j].CreatedAt)
+	})
+
+	// Create the table data
+	tableData := [][]string{
+		{"ID", "TYPE", "STATE", "CREATED"},
+	}
+
+	for _, router := range routers {
+		tableData = append(tableData, []string{
+			router.ID,
+			router.Type,
+			router.State,
+			router.CreatedAt.Format(time.RFC3339),
+		})
+	}
+
+	// Render table
+	pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}
+
+func init() {
+
+}

--- a/cmd/router_shell.go
+++ b/cmd/router_shell.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/automationd/atun/internal/constraints"
+	"github.com/spf13/cobra"
+	"os/signal"
+	"syscall"
+
+	"github.com/automationd/atun/internal/aws"
+	"github.com/automationd/atun/internal/config"
+	"github.com/automationd/atun/internal/tunnel"
+	"github.com/automationd/atun/internal/ux"
+)
+
+// routerShellCmd represents the router ssh command
+var routerShellCmd = &cobra.Command{
+	Use:   "shell",
+	Short: "Connect directly to a router endpoint via SSH",
+	Long: `Connect into a router's shell directly to access the command line.
+This allows you to perform troubleshooting or run commands directly on the router.
+
+Example usage:
+  atun router shell              # Connect to the most recently created router
+  atun router shell --target i-1234abcd  # Connect to a specific router by ID`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var targetID string
+
+		// Create progress spinner
+		sshSpinner := ux.NewProgressSpinner("Connecting to router")
+
+		// TODO: If there are multiple routers, prompt the user to select one using a survey
+		// This is a placeholder for future functionality
+		// if len(routerIDs) > 1 {
+		// 	selectedRouterID, err := ux.SelectRouter(routerIDs)
+		// 	if err != nil {
+		// 		spinner.Fail("Failed to select router")
+		// 		return fmt.Errorf("error selecting router: %w", err)
+		// 	}
+		// 	routerID = selectedRouterID
+		// }
+
+		// Initialize AWS clients
+		sshSpinner.UpdateText("Authenticating with AWS...")
+		aws.InitAWSClients(config.App)
+
+		// Get the connection type and target ID
+		routerType, _ := cmd.Flags().GetString("type")
+		targetID = cmd.Flag("target").Value.String()
+
+		// Default to EC2/SSM if not specified
+		if routerType == "" {
+			routerType = "ec2"
+		}
+
+		// Handle different connection types
+		switch routerType {
+		case "ec2":
+			return consoleToEC2Router(sshSpinner, targetID)
+		// Future connection types
+		case "k8s":
+			sshSpinner.Fail("Kubernetes connections not yet implemented")
+			return fmt.Errorf("kubernetes connections are planned for a future release")
+		case "ecs":
+			sshSpinner.Fail("ECS connections not yet implemented")
+			return fmt.Errorf("ecs connections are planned for a future release")
+		default:
+			sshSpinner.Fail(fmt.Sprintf("Unknown router type: %s", routerType))
+			return fmt.Errorf("router type '%s' not supported", routerType)
+		}
+	},
+}
+
+// consoleToEC2Router manages SSM connections to EC2 router instances
+func consoleToEC2Router(sshSpinner *ux.ProgressSpinner, targetID string) error {
+	var err error
+
+	if err := constraints.CheckConstraints(
+		constraints.WithAWSProfile(),
+		constraints.WithAWSCLI(),
+		constraints.WithSSMPlugin(),
+	); err != nil {
+		return err
+	}
+
+	// If target not provided, get the first running instance
+	if targetID == "" {
+		sshSpinner.UpdateText("Discovering router...")
+		config.App.Config.RouterHostID, err = tunnel.GetRouterHostIDFromTags()
+		if err != nil {
+			sshSpinner.Fail("No routers found with atun.io tags")
+			return fmt.Errorf("no routers found: %w", err)
+		}
+	} else {
+		config.App.Config.RouterHostID = targetID
+	}
+
+	sshSpinner.UpdateText(fmt.Sprintf("Connecting to %s...", config.App.Config.RouterHostID))
+
+	err = aws.ConnectToSSMConsole(config.App.Config.RouterHostID)
+	if err != nil {
+		sshSpinner.Fail("Failed to connect to router", "routerID", config.App.Config.RouterHostID, "error", err)
+		return fmt.Errorf("failed to connect to router: %w", err)
+	}
+
+	return nil
+}
+
+func init() {
+	// Ignore interrupt signals during shell session (Ctrl+C)
+	signal.Ignore(syscall.SIGINT)
+
+	routerShellCmd.Flags().String("target", "", "Target router identifier (instance ID for EC2)")
+	routerShellCmd.Flags().String("type", "", "Router type (ec2, k8s, ecs)")
+}

--- a/cmd/router_uninstall.go
+++ b/cmd/router_uninstall.go
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: © 2024 Dmitry Kireev
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/spf13/cobra"
+
+	awsLib "github.com/automationd/atun/internal/aws"
+	"github.com/automationd/atun/internal/config"
+	"github.com/automationd/atun/internal/constraints"
+	"github.com/automationd/atun/internal/logger"
+	"github.com/automationd/atun/internal/ux"
+)
+
+// routerUninstallCmd represents the router uninstall command
+var routerUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Remove Atun tags from an EC2 instance",
+	Long: `Remove all Atun tags (atun.io/*) from an EC2 instance.
+This command does not terminate or modify the instance, only removes the Atun-specific tags.
+
+Example:
+  atun router uninstall --router i-1234abcd  # Remove Atun tags from instance i-1234abcd`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Create a spinner
+		uninstallSpinner := ux.NewProgressSpinner("Uninstalling Atun from instance")
+
+		// Check constraints
+		if err := constraints.CheckConstraints(
+			constraints.WithAWSProfile(),
+			constraints.WithENV(),
+		); err != nil {
+			uninstallSpinner.Fail("Constraint check failed")
+			return err
+		}
+
+		// Initialize AWS clients
+		uninstallSpinner.UpdateText("Authenticating with AWS...")
+		awsLib.InitAWSClients(config.App)
+
+		// Get router instance ID from flag
+		routerID, _ := cmd.Flags().GetString("router")
+		if routerID == "" {
+			uninstallSpinner.Fail("No router instance ID provided")
+			return fmt.Errorf("router instance ID is required. Use --router flag to specify")
+		}
+
+		// Verify instance exists and get current tags
+		uninstallSpinner.UpdateText(fmt.Sprintf("Verifying instance %s exists and getting tags...", routerID))
+		ec2Client, err := awsLib.NewEC2Client(*config.App.Session.Config)
+		if err != nil {
+			uninstallSpinner.Fail(fmt.Sprintf("Failed to create EC2 client: %v", err))
+			return err
+		}
+
+		result, err := ec2Client.DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(routerID)},
+		})
+		if err != nil {
+			uninstallSpinner.Fail(fmt.Sprintf("Instance %s not found: %v", routerID, err))
+			return fmt.Errorf("instance %s not found: %w", routerID, err)
+		}
+
+		// Ensure we have an instance and it has reservations
+		if len(result.Reservations) == 0 || len(result.Reservations[0].Instances) == 0 {
+			uninstallSpinner.Fail(fmt.Sprintf("Instance %s not found", routerID))
+			return fmt.Errorf("instance %s not found", routerID)
+		}
+
+		// Get the instance's tags
+		instance := result.Reservations[0].Instances[0]
+		var atunTags []*ec2.Tag
+
+		// Find all atun.io/* tags
+		for _, tag := range instance.Tags {
+			if tag.Key != nil && strings.HasPrefix(*tag.Key, "atun.io/") {
+				atunTags = append(atunTags, &ec2.Tag{
+					Key:   tag.Key,
+					Value: tag.Value,
+				})
+			}
+		}
+
+		// Check if any atun.io tags were found
+		if len(atunTags) == 0 {
+			uninstallSpinner.Warning(fmt.Sprintf("No Atun tags found on instance %s", routerID))
+			return nil
+		}
+
+		// Remove the tags
+		uninstallSpinner.UpdateText(fmt.Sprintf("Removing %d Atun tags from instance %s...", len(atunTags), routerID))
+		_, err = ec2Client.DeleteTags(&ec2.DeleteTagsInput{
+			Resources: []*string{aws.String(routerID)},
+			Tags:      atunTags,
+		})
+		if err != nil {
+			uninstallSpinner.Fail(fmt.Sprintf("Failed to remove tags: %v", err))
+			return fmt.Errorf("failed to remove tags: %w", err)
+		}
+
+		// If this is the current router host in config, clear it
+		if config.App.Config.RouterHostID == routerID {
+			config.App.Config.RouterHostID = ""
+		}
+
+		uninstallSpinner.Success(fmt.Sprintf("Successfully removed %d Atun tags from instance %s", len(atunTags), routerID))
+		logger.Info(fmt.Sprintf("Atun tags removed from instance %s", routerID))
+
+		return nil
+	},
+}
+
+func init() {
+	routerCmd.AddCommand(routerUninstallCmd)
+	routerUninstallCmd.Flags().String("router", "", "ID of the EC2 instance to remove Atun tags from (required)")
+	routerUninstallCmd.MarkFlagRequired("router")
+}

--- a/examples/simple/atun.example.toml
+++ b/examples/simple/atun.example.toml
@@ -1,10 +1,10 @@
-# This is a sample config file that is used when atun cli is ued to deploy a Bastion Host.
-# It's not required when connecting to an existing Bastion Host that is tagged with atun-compatible tags.
+# This is a sample config file that is used when atun cli is ued to deploy a Router Host.
+# It's not required when connecting to an existing Router Host that is tagged with atun-compatible tags.
 
 #aws_profile="localstack"
 aws_region="us-east-1"
-#bastion_subnet_id="subnet-xxxxxxxxxxxxxxxx"
-#bastion_subnet_id="subnet-77c1c72b"
+#router_subnet_id="subnet-xxxxxxxxxxxxxxxx"
+#router_subnet_id="subnet-77c1c72b"
 
 [[hosts]]
 name = "ipconfig.io"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,12 +36,12 @@ type Config struct {
 	AWSEndpointUrl           string
 	AWSInstanceType          string
 	ConfigFile               string
-	BastionVPCID             string
-	BastionSubnetID          string
-	BastionHostID            string
-	BastionInstanceName      string
-	BastionHostAMI           string
-	BastionHostUser          string
+	RouterVPCID              string
+	RouterSubnetID           string
+	RouterHostID             string
+	RouterInstanceName       string
+	RouterHostAMI            string
+	RouterHostUser           string
 	AppDir                   string
 	TunnelDir                string
 	LogLevel                 string
@@ -151,7 +151,7 @@ func LoadConfig() error {
 	viper.SetDefault("SSH_KEY_PATH", filepath.Join(homeDir, ".ssh", "id_rsa"))
 	viper.SetDefault("SSH_STRICT_HOST_KEY_CHECKING", true)
 	viper.SetDefault("AWS_INSTANCE_TYPE", "t3.nano")
-	viper.SetDefault("BASTION_INSTANCE_NAME", "atun-bastion")
+	viper.SetDefault("ROUTER_INSTANCE_NAME", "atun-router")
 	viper.SetDefault("SSH_STRICT_HOST_KEY_CHECKING", false) // Strict host key checking is disabled by default for better user experience. Debatable
 	viper.SetDefault("AUTO_ALLOCATE_PORT", false)           // Port auto-allocation is disabled by default
 	viper.SetDefault("LOG_PLAIN_TEXT", false)               // Set LOG_PLAIN_TEXT to false by default
@@ -170,12 +170,12 @@ func LoadConfig() error {
 			AWSKeyPair:               viper.GetString("AWS_KEY_PAIR"),
 			AWSInstanceType:          viper.GetString("AWS_INSTANCE_TYPE"),
 			AWSEndpointUrl:           viper.GetString("AWS_ENDPOINT_URL"),
-			BastionVPCID:             viper.GetString("BASTION_VPC_ID"),
-			BastionSubnetID:          viper.GetString("BASTION_SUBNET_ID"),
-			BastionHostID:            viper.GetString("BASTION_HOST_ID"),
-			BastionInstanceName:      viper.GetString("BASTION_INSTANCE_NAME"),
-			BastionHostAMI:           viper.GetString("BASTION_HOST_AMI"),
-			BastionHostUser:          viper.GetString("BASTION_HOST_USER"),
+			RouterVPCID:              viper.GetString("ROUTER_VPC_ID"),
+			RouterSubnetID:           viper.GetString("ROUTER_SUBNET_ID"),
+			RouterHostID:             viper.GetString("ROUTER_HOST_ID"),
+			RouterInstanceName:       viper.GetString("ROUTER_INSTANCE_NAME"),
+			RouterHostAMI:            viper.GetString("ROUTER_HOST_AMI"),
+			RouterHostUser:           viper.GetString("ROUTER_HOST_USER"),
 			ConfigFile:               viper.ConfigFileUsed(),
 			AppDir:                   appDir,
 			LogLevel:                 viper.GetString("LOG_LEVEL"),
@@ -202,7 +202,7 @@ func LoadConfig() error {
 	//
 	//pterm.Printfln("Config: %v", App.Config)
 
-	// TODO?: Maybe search for bastion host id during config stage?
+	// TODO?: Maybe search for router host id during config stage?
 	return nil
 }
 
@@ -217,8 +217,8 @@ func SaveConfig() error {
 	configFilePath := filepath.Join(currentDir, "atun.toml")
 
 	// TODO: Possibly find a better way to marshal the whole config
-	// Add bastion subnet id to the viper config
-	viper.Set("bastion_subnet_id", App.Config.BastionSubnetID)
+	// Add router subnet id to the viper config
+	viper.Set("router_subnet_id", App.Config.RouterSubnetID)
 
 	// Add hosts to the the config
 	viper.Set("hosts", App.Config.Hosts)

--- a/internal/infra/cdktf.go
+++ b/internal/infra/cdktf.go
@@ -157,7 +157,7 @@ func createStack(c *config.Config) {
 
 	cdktf.NewTerraformHclModule(stack, jsii.String("router"), &cdktf.TerraformHclModuleConfig{
 		// TODO: Make an abstraction atun-router module so anyone can fork and switch configs
-		Source:  jsii.String("hazelops/ec2-router/aws"),
+		Source:  jsii.String("hazelops/ec2-bastion/aws"),
 		Version: jsii.String("~>4.0"),
 
 		Variables: &terraformVariablesModules,

--- a/internal/infra/tf.go
+++ b/internal/infra/tf.go
@@ -95,6 +95,7 @@ func InstallTerraform(version string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get latest version: %w", err)
 		}
+		logger.Debug("Latest Terraform", "version", version)
 	}
 
 	// Determine the correct download URL based on OS and architecture

--- a/schemas/schema.json
+++ b/schemas/schema.json
@@ -32,7 +32,7 @@
             },
             "remote": {
               "type": "integer",
-              "description": "Port of the remote host on the internal network. Must be accessible to the bastion host",
+              "description": "Port of the remote host on the internal network. Must be accessible to the router host",
               "minimum": 1,
               "maximum": 65535
             }

--- a/test/e2e/create_delete_test.go
+++ b/test/e2e/create_delete_test.go
@@ -149,7 +149,7 @@ func TestAtunCreateDelete(t *testing.T) {
 		{
 			name:           "Interactive terminal",
 			interactive:    true,
-			expectedOutput: "Creating Ad-Hoc EC2 Bastion Instance...",
+			expectedOutput: "Creating Ad-Hoc EC2 Router Instance...",
 			envVars: map[string]string{
 				"TERM":                "xterm-256color",
 				"NO_COLOR":            "",
@@ -161,7 +161,7 @@ func TestAtunCreateDelete(t *testing.T) {
 		{
 			name:           "Non-interactive terminal",
 			interactive:    false,
-			expectedOutput: "Creating Ad-Hoc EC2 Bastion Instance...",
+			expectedOutput: "Creating Ad-Hoc EC2 Router Instance...",
 			envVars: map[string]string{
 				"TERM":           "",
 				"NO_COLOR":       "1",
@@ -348,8 +348,8 @@ func prepareWorkDir(t *testing.T, subnetID string, amiID string) string {
 	tmpDir, _ := os.MkdirTemp("", "atun")
 	content := fmt.Sprintf(`
 aws_profile = "localstack"
-bastion_subnet_id = "%s"
-bastion_host_ami = "%s"
+router_subnet_id = "%s"
+router_host_ami = "%s"
 [[hosts]]
 name = "ipconfig.io"
 proto = "ssm"

--- a/test/e2e/router_create_router_delete_test.go
+++ b/test/e2e/router_create_router_delete_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -102,7 +103,15 @@ func (s *testSetup) cleanupTestEnvironment(t *testing.T) {
 
 // runAtunCommand is a helper function to run Atun commands with consistent environment setup
 func runAtunCommand(t *testing.T, workDir, command string, interactive bool, envVars map[string]string) {
-	cmd := exec.Command("atun", command)
+
+	// get path to the directory where the test is running
+	_, filename, _, _ := runtime.Caller(0)
+	// Get bin dir
+	binDir := filepath.Join(filepath.Dir(filename), "..", "..", "bin")
+
+	t.Log("binDir: ", binDir)
+
+	cmd := exec.Command(path.Join(binDir, "atun"), strings.Fields(command)...)
 	cmd.Dir = workDir
 
 	// Set up environment variables
@@ -116,6 +125,7 @@ func runAtunCommand(t *testing.T, workDir, command string, interactive bool, env
 
 	// Set up command environment
 	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("PATH=./bin/:%s", os.Getenv("PATH")),
 		fmt.Sprintf("AWS_PROFILE=%s", os.Getenv("AWS_PROFILE")),
 		fmt.Sprintf("AWS_CONFIG_FILE=%s", os.Getenv("AWS_CONFIG_FILE")),
 		fmt.Sprintf("AWS_SHARED_CREDENTIALS_FILE=%s", os.Getenv("AWS_SHARED_CREDENTIALS_FILE")),
@@ -138,8 +148,8 @@ func runAtunCommand(t *testing.T, workDir, command string, interactive bool, env
 	}
 }
 
-// TestAtunCreateDelete tests the create/delete flow in both interactive and non-interactive modes
-func TestAtunCreateDelete(t *testing.T) {
+// TestAtunRouterCreateRouterDelete tests the create/delete flow in both interactive and non-interactive modes
+func TestAtunRouterCreateRouterDelete(t *testing.T) {
 	tests := []struct {
 		name           string
 		interactive    bool
@@ -179,14 +189,14 @@ func TestAtunCreateDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Run create command
-			runAtunCommand(t, setup.workDir, "create", tt.interactive, tt.envVars)
+			runAtunCommand(t, setup.workDir, "router create", tt.interactive, tt.envVars)
 
 			// Verify EC2 Instance Exists
 			instanceID := verifyEC2Instance(t, setup.ec2Client, "atun.io/version", "1")
 			t.Logf("EC2 instance created successfully with ID: %s", instanceID)
 
 			// Run delete command
-			runAtunCommand(t, setup.workDir, "delete", tt.interactive, tt.envVars)
+			runAtunCommand(t, setup.workDir, "router delete", tt.interactive, tt.envVars)
 
 			// Verify EC2 Instance Removed
 			verifyInstanceDeleted(t, setup.ec2Client, instanceID)


### PR DESCRIPTION
# Description
- Rename Bastion to Router throughout the codebase
- Add Console command for Router
- Break down router command into create and delete
- Add Install/Uninstall for router (tags for instances)
- Add router list/ls command for available routers

